### PR TITLE
[DEV]룸메이트 매칭 결과 페이지 - 인트로 페이지 추가

### DIFF
--- a/src/forpractice/ForPractice.tsx
+++ b/src/forpractice/ForPractice.tsx
@@ -1,6 +1,6 @@
-import { Intro2 } from "../pages/roommatelist/Intro2"
+import { Intro3 } from "../pages/roommatelist/Intro3"
 export function ForPractice() {
     return (
-       <Intro2 />
+       <Intro3 />
     )
 }

--- a/src/pages/roommatelist/Intro3.tsx
+++ b/src/pages/roommatelist/Intro3.tsx
@@ -1,0 +1,14 @@
+import ProgressIndLinear from "../../components/common/ProgressIndLinear"
+
+export const Intro3 = () =>{
+    return (
+        <div className="">
+            <div className="font-['700'] text-2xl mt-8">모글리님에게 어울리는 룸메이트를 찾고 있습니다!</div>
+            <div className="font-['400'] mt-8 mb-2">잠시만 기다려주세요</div>
+            <div className="mb-2">
+                <img src={process.env.PUBLIC_URL + '/puang1.png'} alt="monkey" style={{width : '300px'}}/>
+            </div>
+            <ProgressIndLinear />
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary
룸메이트 매칭 결과 페이지를 보여주기 전에 인트로 페이지를 추가 구현하였습니다.

## Description
<img width="123" alt="스크린샷 2023-11-12 오전 10 42 11" src="https://github.com/Capstone-2023-2/Roomate-FE/assets/81398185/4aceaca8-7f07-4b30-829a-c08a0dab1fbb">
